### PR TITLE
Fix a couple issues triggered in Firefox

### DIFF
--- a/background.js
+++ b/background.js
@@ -757,6 +757,7 @@ function getBrowserVariables(tid, cStoreId) {
         method: "getVars",
         myVars: "g_ck,g_user_date_time_format,NOW.user.roles,NOW.user.name,NOW.user_name"
     }, function (response) {
+        if (response == null || typeof response !== 'object') return;
         g_ck = response.myVars.g_ck || '';
         url = response.url;
         instance = (new URL(url)).host.replace(".service-now.com", "");

--- a/content_script_all_frames.js
+++ b/content_script_all_frames.js
@@ -60,15 +60,20 @@ function setFavIconBadge(settings) {
 }
 
 function runFunction(f, context) {
-    var doc;
+    let doc = document?.querySelector('#gsft_main')?.contentWindow?.document;
 
-    if (context == 'child' && jQuery('#gsft_main').length)
+    if (context == 'child' && doc) {
+        // don't run function meant for content frame if we're not in it
         return;
+    }
 
-    if (jQuery('#gsft_main').length)
-        doc = jQuery('#gsft_main')[0].contentWindow.document;
-    else
+    if (doc == null && typeof document === 'undefined') {
+        // we can find neither the content frame nor `document`, for some reason; exit right away
+        return;
+    } else if (doc == null) {
+        // we're on the content frame itself, use 'document' directly
         doc = document;
+    }
 
     var script = doc.createElement('script');
     script.appendChild(doc.createTextNode(f));


### PR DESCRIPTION
`can't access property "myVars", response is undefined`
and
`Unchecked lastError value: Error: can't access property "appendChild", doc.body is null`

---

I don't exactly know how to reproduce how these errors appeared. I was changing a few built-in slashcommands to include an extra query, and after modifying a few of them, suddenly the slashcommands list didn't load anymore. After restarting the browser a few it eventually loaded again and I didn't see these errors again. 