### PR TITLE
Only exactly "admin" update read-only fields

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -1049,7 +1049,7 @@ function doubleClickToShowFieldOrReload() {
             if (event.target.classList.contains('label-text') || event.target.parentElement.classList.contains('label-text')) {
                 var elm = jQuery(event.target).closest('div.form-group').attr('id').split('.').slice(2).join('.');
                 var val = g_form.getValue(elm);
-                if (NOW.user.roles.includes('admin')) { //only allow "admin" ti change fields
+                if (NOW.user.roles.split(",").includes('admin')) { //only allow "admin" to change fields
                     var newValue = prompt('[SN Utils]\nValue of ' + elm, val);
                     if (newValue !== null)
                         g_form.setValue(elm, newValue);


### PR DESCRIPTION
NOW.user.roles is a comma-separated list of roles. Splitting this on the comma and using Array .includes() means you get an exact match on "admin" and not on other admin roles (e.g. "itil_admin")