### PR TITLE
Add /t slashcommand for opening any task by number quickly

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -169,6 +169,10 @@ var snuslashcommands = {
         "url": "*",
         "hint": "Instance search <sys_id>"
     },
+    "t": {
+        "url": "/task.do?sysparm_query=number=$0",
+        "hint": "Open task with this number"
+    },
     "tn": {
         "url": "*",
         "hint": "Show Technical Names"


### PR DESCRIPTION
I've added this for myself and found myself using it quite a bit over the past few months, as it's super easy to copy paste a number into the command to open that record in a new tab. 
While its possible to get the same result with the right-click context menu, this way can be done with all keyboard shortcuts (once the number is in your clipboard)