### PR TITLE
Fix: empty link text in the clickToList function

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -1214,7 +1214,7 @@ function clickToList() {
                     tpe = g_form.getGlideUIElement(elm).type;
                     val = g_form.getValue(elm);
                     elmDisp = jQuery(event.target).text();
-                    valDisp = g_form.getDisplayBox(elm) ? g_form.getDisplayBox(elm).value : g_form.getValue(elm);
+                    valDisp = g_form.getDisplayBox(elm) && g_form.getDisplayBox(elm).value || g_form.getValue(elm);
                 }
                 if (jQuery(event.target).hasClass('container-fluid')) {
                     elm = 'sys_id';


### PR DESCRIPTION
In some cases the text link with the predefined filter to list is empty.

The issue is described here: #123.