### PR TITLE
add default api search

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -17,6 +17,10 @@ var snuslashcommands = {
         "hint": "Filter ACL list <table> <operation>",
         "fields": "name"
     },
+    "api": {
+        "url": "https://developer.servicenow.com/dev.do#!/search/aspen/Reference/$0",//searching aspen redirects to most recent current family
+        "hint": "Search Developer References <search>"
+    },
     "app": {
         "url": "sys_scope_list.do?sysparm_query=nameLIKE$0^scopeLIKE$0^ORDERBYDESCsys_updated_on",
         "hint": "Filter Applications <name>",


### PR DESCRIPTION
Hey a while back someone asked for a search to specific family docs in #51 

I liked that idea and it was .. closed as it's not worht the extra complexity.
I concur.  however I generally only want the reference results from the devloper.servicenow.com site.

I can add this as my own slash command but thought, hey maybe Arnoud would want this too.  So the PR is here.

This will a slashcommand for /api term to `https://developer.servicenow.com/dev.do#!/search/aspen/Reference/term`
Which in turn redirects to 
https://developer.servicenow.com/dev.do#!/search/quebec/Reference/term ( i think its to the most recent non-ea release)

If you dont want it just close it up.  