### PR TITLE
Fix: unescaped character in the clickToList function

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -1250,8 +1250,6 @@ function clickToList() {
                     operator = 'LIKE';
                 }
 
-                // The caret is a reserved character used to separate subconditions and must be escaped
-                val = val.replace(/\^/g, '^^');
                 // Some characters cannot be part of a URL
                 val = encodeURIComponent(val);
                 // ServiceNow uses CR LF to encode newlines. The only exceptions are script fields - some of them use LF, others use CR LF.

--- a/inject.js
+++ b/inject.js
@@ -1250,6 +1250,8 @@ function clickToList() {
                     operator = 'LIKE';
                 }
 
+                // The caret is a reserved character used to separate subconditions and must be escaped
+                val = val.replace(/\^/g, '^^');
                 // Some characters cannot be part of a URL
                 val = encodeURIComponent(val);
                 // ServiceNow uses CR LF to encode newlines. The only exceptions are script fields - some of them use LF, others use CR LF.

--- a/inject.js
+++ b/inject.js
@@ -17,10 +17,6 @@ var snuslashcommands = {
         "hint": "Filter ACL list <table> <operation>",
         "fields": "name"
     },
-    "api": {
-        "url": "https://developer.servicenow.com/dev.do#!/search/aspen/Reference/$0",//searching aspen redirects to most recent current family
-        "hint": "Search Developer References <search>"
-    },
     "app": {
         "url": "sys_scope_list.do?sysparm_query=nameLIKE$0^scopeLIKE$0^ORDERBYDESCsys_updated_on",
         "hint": "Filter Applications <name>",

--- a/inject.js
+++ b/inject.js
@@ -1199,6 +1199,7 @@ function doubleClickToSetQueryListV2() { //dbl click to view and update filter c
 
 var qry = '';
 var qryDisp = '';
+var _qry = {};
 
 function clickToList() {
 
@@ -1261,13 +1262,27 @@ function clickToList() {
                 // But since this feature is mainly used with other types of fields, we can ignore the support of multiline scripts.
                 val = val.replace(/%0A/g, '%0D%0A');
 
-                var idx = qry.indexOf(elm + operator);
-                if (idx > -1) {
-                    qry = qry.replace(elm + operator + val + '^', '');
-                    qryDisp = qryDisp.replace(elmDisp + ' ' + operator + ' <b>' + valDisp + '</b> > ', '');
+                _qry = typeof _qry == 'object' ? _qry : {};
+
+                var subCondition = {
+                    val: val,
+                    valDisp: valDisp,
+                    elmDisp: elmDisp,
+                    operator: operator
+                };
+
+                if (_qry[elm] && _qry[elm].val == subCondition.val && _qry[elm].operator == subCondition.operator) {
+                    // Double function call in case of no changes removes the subcondition
+                    delete _qry[elm];
                 } else {
-                    qry += elm + operator + val + '^';
-                    qryDisp += elmDisp + ' ' + operator + ' <b>' + valDisp + '</b> > ';
+                    _qry[elm] = subCondition;
+                }
+
+                var qry = '';
+                var qryDisp = '';
+                for (var _elm in _qry) {
+                    qry += _elm + _qry[_elm].operator + _qry[_elm].val + '^';
+                    qryDisp += _qry[_elm].elmDisp + ' ' + _qry[_elm].operator + ' <b>' + _qry[_elm].valDisp + '</b> > ';
                 }
 
                 var listurl = '/' + tbl + '_list.do?sysparm_query=' + qry;
@@ -1404,6 +1419,7 @@ function getFieldStates() {
 function delQry() {
     qry = '';
     qryDisp = '';
+    _qry = {};
     g_form.clearMessages();
 }
 

--- a/inject.js
+++ b/inject.js
@@ -17,14 +17,14 @@ var snuslashcommands = {
         "hint": "Filter ACL list <table> <operation>",
         "fields": "name"
     },
+    "api": {
+        "url": "https://developer.servicenow.com/dev.do#!/search/aspen/Reference/$0",//searching aspen redirects to most recent current family
+        "hint": "Search Developer References <search>"
+    },
     "app": {
         "url": "sys_scope_list.do?sysparm_query=nameLIKE$0^scopeLIKE$0^ORDERBYDESCsys_updated_on",
         "hint": "Filter Applications <name>",
         "fields": "name"
-    },
-    "api": {
-        "url": "https://developer.servicenow.com/dev.do#!/search/aspen/Reference/$0",//searching aspen redirects to most recent current family
-        "hint": "Search Developer References <search>"
     },
     "aes": {
         "url": "/now/appenginestudio",

--- a/inject.js
+++ b/inject.js
@@ -22,6 +22,10 @@ var snuslashcommands = {
         "hint": "Filter Applications <name>",
         "fields": "name"
     },
+    "api": {
+        "url": "https://developer.servicenow.com/dev.do#!/search/aspen/Reference/$0",//searching aspen redirects to most recent current family
+        "hint": "Search Developer References <search>"
+    },
     "aes": {
         "url": "/now/appenginestudio",
         "hint": "Open App Engine Studio"

--- a/inject.js
+++ b/inject.js
@@ -1199,7 +1199,6 @@ function doubleClickToSetQueryListV2() { //dbl click to view and update filter c
 
 var qry = '';
 var qryDisp = '';
-var _qry = {};
 
 function clickToList() {
 
@@ -1262,27 +1261,13 @@ function clickToList() {
                 // But since this feature is mainly used with other types of fields, we can ignore the support of multiline scripts.
                 val = val.replace(/%0A/g, '%0D%0A');
 
-                _qry = typeof _qry == 'object' ? _qry : {};
-
-                var subCondition = {
-                    val: val,
-                    valDisp: valDisp,
-                    elmDisp: elmDisp,
-                    operator: operator
-                };
-
-                if (_qry[elm] && _qry[elm].val == subCondition.val && _qry[elm].operator == subCondition.operator) {
-                    // Double function call in case of no changes removes the subcondition
-                    delete _qry[elm];
+                var idx = qry.indexOf(elm + operator);
+                if (idx > -1) {
+                    qry = qry.replace(elm + operator + val + '^', '');
+                    qryDisp = qryDisp.replace(elmDisp + ' ' + operator + ' <b>' + valDisp + '</b> > ', '');
                 } else {
-                    _qry[elm] = subCondition;
-                }
-
-                var qry = '';
-                var qryDisp = '';
-                for (var _elm in _qry) {
-                    qry += _elm + _qry[_elm].operator + _qry[_elm].val + '^';
-                    qryDisp += _qry[_elm].elmDisp + ' ' + _qry[_elm].operator + ' <b>' + _qry[_elm].valDisp + '</b> > ';
+                    qry += elm + operator + val + '^';
+                    qryDisp += elmDisp + ' ' + operator + ' <b>' + valDisp + '</b> > ';
                 }
 
                 var listurl = '/' + tbl + '_list.do?sysparm_query=' + qry;
@@ -1419,7 +1404,6 @@ function getFieldStates() {
 function delQry() {
     qry = '';
     qryDisp = '';
-    _qry = {};
     g_form.clearMessages();
 }
 


### PR DESCRIPTION
The issue is described here: #130.

The _clickToList_ does not work if the value contains a caret character.