### PR TITLE
fix: make node switching work with custom URLs

### DIFF
--- a/background.js
+++ b/background.js
@@ -1173,21 +1173,29 @@ function setActiveNode(nodeId, nodeName) {
             var port = ($($.parseXML(jsn.result[0].stats)).find('servlet\\.port').text());
             var encodedPort = Math.floor(port / 256) + (port % 256) * 256;
             var encodeBIGIP = encodedIP + '.' + encodedPort + '.0000';
-            chrome.cookies.set({
-                "name": "BIGipServerpool_" + instance,
-                "url": new URL(url).origin,
-                "secure": true,
-                "httpOnly": true,
-                "value": encodeBIGIP
-            }, function (s) {
+            chrome.cookies.getAll({
+                url: new URL(url).origin
+            }, function (instanceCookies) {
+                var BIGipServerpoolCookie = instanceCookies.find(function (cookie) {
+                    // matches BIGipServerpool_<alphanumeric instance name>
+                    return cookie.name.match(/^(BIGipServerpool_[\w\d]+)$/);
+                });
                 chrome.cookies.set({
-                    "name": "glide_user_route",
+                    "name": BIGipServerpoolCookie.name,
                     "url": new URL(url).origin,
                     "secure": true,
                     "httpOnly": true,
-                    "value": 'glide.' + nodeId
+                    "value": encodeBIGIP
                 }, function (s) {
-                    getActiveNode(jsnNodes);
+                    chrome.cookies.set({
+                        "name": "glide_user_route",
+                        "url": new URL(url).origin,
+                        "secure": true,
+                        "httpOnly": true,
+                        "value": 'glide.' + nodeId
+                    }, function (s) {
+                        getActiveNode(jsnNodes);
+                    });
                 });
             });
         });


### PR DESCRIPTION
ServiceNow stores an encoded identifier for the node to connect to in
the cookie `BIGipServerpool_<instance name>`.

We were calculating the cookie name by pulling instance name from the
URL, however we cannot do this with a custom URL and `<instance name>` 
was being set as the full custom URL.

This meant we were creating a new cookie, rather than editing the one
that drives node connection.

This change makes setActiveNode pull the cookie name from the existing
cookie rather than calculating it, ensuring we set the value of the
right cookie.

Fixes #136. More details can be found there.