### PR TITLE
fix: generate correct node BIG IP encoded port

### DIFF
--- a/background.js
+++ b/background.js
@@ -1168,7 +1168,7 @@ function setActiveNode(nodeId, nodeName) {
         }
 
 
-        var myurl = url + '/api/now/table/sys_cluster_state?sysparm_query=node_id=' + nodeId + '&sysparm_fields=stats';
+        var myurl = url + '/api/now/table/sys_cluster_node_stats?sysparm_query=node_id=' + nodeId + '&sysparm_fields=stats';
         loadXMLDoc(g_ck, myurl, null, function (jsn) {
             var port = ($($.parseXML(jsn.result[0].stats)).find('servlet\\.port').text());
             var encodedPort = Math.floor(port / 256) + (port % 256) * 256;


### PR DESCRIPTION
ServiceNow stores an encoded identifier for the node to connect to in
the cookie `BIGipServerpool_<instance name>`.

We have to calculate this value in order to set the cookie to direct
us to the desired node. This calculation was failing for the encoded
port section of the BIG IP because we were pulling node stats from
an incorrect location. I suspect an upgrade changed the location
they are stored in but cannot confirm that.

This commit makes us pull the node stats xml from the correct
location, so that we can parse the port and encode it.

More details can be found in issue #138 