### PR TITLE
adds links to errors in the log which point to scripts / business rules etc.

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -1071,6 +1071,7 @@ function snuSettingsAdded() {
         createHyperLinkForGlideLists();
         mouseEnterToConvertToHyperlink();
         snuAddGroupSortIcon();
+        snuAddErrorLogScriptLinks();
     }
 
     if (snusettings.hasOwnProperty("slashcommands")) {
@@ -1200,6 +1201,23 @@ function snuAddGroupSortIcon(){
         })
 
     }
+}
+
+function snuAddErrorLogScriptLinks(){
+    if (location.pathname.includes("syslog_list.do")){
+    jQuery("td.vt:contains('Caused by error')").each(function(tableCellIndex, tableCell) {
+        var regex = /Caused by error in (([a-z_]+).([A-Za-z0-9]+).[a-z]+) at line ([0-9]+)/;
+        var found = tableCell.innerText.match(regex);
+        if(found !== null) {
+            tableCell.innerHTML = tableCell.innerHTML.replace(found[1], buildLink(found[2], found[3], found[1]));
+        }
+    });
+    }
+}
+  
+function buildLink(table, sysId, linkText) {
+    var link = '<a href="/'+ table + '?sys_id=' + sysId + '">' + linkText + '</a>';
+    return link;
 }
 
 function doubleClickToSetQueryListV2() { //dbl click to view and update filter condition


### PR DESCRIPTION
I often see myself doing the same thing again and again.
I would like just to click on the script and land on the particular script or business rule if present in the log.
I added the functionality to the plugin with the following parts:
- added function to build a link in the dom (buildLink(...) function)
- added function to fetch cell content of a message in the syslog and transform text to links (snuAddErrorLogScriptLinks() function)

The function will be activated with the ui elements that are added to the browser.
See attached screenshot for a preview.

<img width="1398" alt="logling-preview" src="https://user-images.githubusercontent.com/2991341/140592092-e9a2b6c0-6e8e-411a-b479-7e22a2a76c2d.png">


