### PR TITLE
Add sys_rte_eb_script_operation to codesearch

### DIFF
--- a/codesearch.js
+++ b/codesearch.js
@@ -104,7 +104,8 @@ var suggestedtables = [
   ['sys_web_service', 'script', 'active=true'],
   ['sys_widgets', 'name,script', 'active=true'],
   ['sys_ws_operation', 'operation_script', 'active=true'],
-  ['wf_activity_definition', 'name,script', '']
+  ['wf_activity_definition', 'name,script', ''],
+  ['sys_rte_eb_script_operation', 'script,conditional_script', '']
 ];
 
 var missingtables = [];


### PR DESCRIPTION
Adding the sys_rte_eb_script_operation table to the suggested code search table list as suggested by Sebastian on #sn-utils