### PR TITLE
findSysID: ignore Remote Tables

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -3712,7 +3712,7 @@ function snuSearchSysIdTables(sysId) {
                 }
 
                 var tblsGr = new GlideRecord("sys_db_object");
-                tblsGr.addEncodedQuery("super_class=NULL^sys_update_nameISNOTEMPTY^nameNOT LIKE00^nameNOT LIKE$^nameNOT INsys_metadata,task,cmdb_ci,sys_user,cmdb_ire_partial_payloads_index");
+                tblsGr.addEncodedQuery("super_class=NULL^sys_update_nameISNOTEMPTY^nameNOT LIKE00^nameNOT LIKE$^nameNOT INsys_metadata,task,cmdb_ci,sys_user,cmdb_ire_partial_payloads_index^scriptable_table=false");
                 tblsGr.query();
                 while (tblsGr.next()) {
                     var tableName = tblsGr.getValue('name');


### PR DESCRIPTION
Queries to these tables usually involve API calls which might fail/take a long time.