### PR TITLE
Add generic support for links to scripts from syslog messages

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -1670,7 +1670,10 @@ function snuAddErrorLogScriptLinks() {
             }
         });
 
-        // links for NiceError stack traces
+        // Added support for 3 different patterns of script ids being present in logs:
+        // table_name:sys_id
+        // table_name.sys_id
+        // table_name_sys_id
         jQuery("td.vt:contains('-------- STACK TRACE ---------')").each(function (
             tableCellIndex,
             tableCell
@@ -1688,7 +1691,6 @@ function snuAddErrorLogScriptLinks() {
                 if(idx == 2) splitter = "_";
 
                 var found = tableCell.innerText.match(pattern);
-                console.log(`Pattern: ${idx} Splitter ${splitter}`, found);
 
                 if(found != null){
                     found.forEach(find => {
@@ -1700,9 +1702,9 @@ function snuAddErrorLogScriptLinks() {
                             sys_id = segments[1];
                         } else if (idx == 2){
                             /*
-                            Given this line: com.glide.caller.gen.sys_script_include_b0dee9462f231110c30d2ca62799b62d_script.call(Unknown Source)
+                            Given this line: `com.glide.caller.gen.sys_script_include_b0dee9462f231110c30d2ca62799b62d_script.call(Unknown Source)`
                             Pattern will give this regex match: "sys_script_include_fc70ddc629230010fa9bf7f97d737e2e"
-                            Segments looks like this: ['sys', 'script', 'include', 'fc70ddc629230010fa9bf7f97d737e2e']
+                            `segments` looks like this: ['sys', 'script', 'include', 'fc70ddc629230010fa9bf7f97d737e2e']
                             Hence using slice and join to reconstruct the table name
                             */
                             var sys_id_idx = segments.length - 1;

--- a/inject.js
+++ b/inject.js
@@ -1675,20 +1675,49 @@ function snuAddErrorLogScriptLinks() {
             tableCellIndex,
             tableCell
         ) {
-            var regex = /(([a-z_]+):([a-z0-9]+))/gm;
-            var found = tableCell.innerText.match(regex);
-            if (found !== null) {
-                found.forEach(function (find) {
-                    var str = find.split(":");
-                    var t = str[0];
-                    var id = str[1];
-                    var newHtml = tableCell.innerHTML.replaceAll(
-                        find,
-                        `<a title="Link via SN Utils" href='/${t}.do?sys_id=${id}'>${find}</a>`
-                    );
-                    tableCell.innerHTML = DOMPurify.sanitize(newHtml, { ADD_ATTR: ["target"] });
-                });
-            }
+            var patterns = [
+                /(([a-z_]+):([a-z0-9]{32}))/gm, // table_name:sys_id
+                /(([a-z_]+)\.([a-z0-9]{32})\.([a-z_]+))/gm, // table_name.sys_id.field
+                /(([a-z_]+)_([a-z0-9]{32}))/gm, // table_name_sys_id_field
+            ];
+
+            patterns.forEach((pattern, idx) => {
+                var splitter;
+                if(idx == 0) splitter = ":";
+                if(idx == 1) splitter = ".";
+                if(idx == 2) splitter = "_";
+
+                var found = tableCell.innerText.match(pattern);
+                console.log(`Pattern: ${idx} Splitter ${splitter}`, found);
+
+                if(found != null){
+                    found.forEach(find => {
+                        var segments = find.split(splitter);
+                        var table;
+                        var sys_id;
+                        if(idx == 0 || idx == 1){
+                            table = segments[0];
+                            sys_id = segments[1];
+                        } else if (idx == 2){
+                            /*
+                            Given this line: com.glide.caller.gen.sys_script_include_b0dee9462f231110c30d2ca62799b62d_script.call(Unknown Source)
+                            Pattern will give this regex match: "sys_script_include_fc70ddc629230010fa9bf7f97d737e2e"
+                            Segments looks like this: ['sys', 'script', 'include', 'fc70ddc629230010fa9bf7f97d737e2e']
+                            Hence using slice and join to reconstruct the table name
+                            */
+                            var sys_id_idx = segments.length - 1;
+                            sys_id = segments[sys_id_idx];
+                            table = segments.slice(0, sys_id_idx).join(splitter);
+                        }
+
+                        var newHtml = tableCell.innerHTML.replaceAll(
+                            find,
+                            `<a title="Link via SN Utils" href='/${table}.do?sys_id=${sys_id}'>${find}</a>`
+                        );
+                        tableCell.innerHTML = DOMPurify.sanitize(newHtml, { ADD_ATTR: ["target"] });
+                    });
+                }
+            });
         });
     }
 }

--- a/inject.js
+++ b/inject.js
@@ -1658,26 +1658,11 @@ function snuAddGroupSortIcon() {
 
 function snuAddErrorLogScriptLinks() {
     if (location.pathname.includes("syslog_list.do")) {
-        jQuery("td.vt:contains('Caused by error')").each(function (tableCellIndex, tableCell) {
-            var regex = /Caused by error in (([a-z_]+).([A-Za-z0-9]+).[a-z]+) at line ([0-9]+)/;
-            var found = tableCell.innerText.match(regex);
-            if (found !== null) {
-                var newHtml = tableCell.innerHTML.replace(
-                    found[1],
-                    `<a title="Link via SN Utils" href='/${found[2]}.do?sys_id=${found[3]}'>${found[1]}</a>`
-                );
-                tableCell.innerHTML = DOMPurify.sanitize(newHtml, { ADD_ATTR: ["target"] });
-            }
-        });
-
-        // Added support for 3 different patterns of script ids being present in logs:
+        // Supports for 3 different patterns of script ids being present in logs:
         // table_name:sys_id
         // table_name.sys_id
         // table_name_sys_id
-        jQuery("td.vt:contains('-------- STACK TRACE ---------')").each(function (
-            tableCellIndex,
-            tableCell
-        ) {
+        document.querySelectorAll('td.vt',).forEach((tableCell,tableCellIndex) => {
             var patterns = [
                 /(([a-z_]+):([a-z0-9]{32}))/gm, // table_name:sys_id
                 /(([a-z_]+)\.([a-z0-9]{32})\.([a-z_]+))/gm, // table_name.sys_id.field
@@ -1685,22 +1670,15 @@ function snuAddErrorLogScriptLinks() {
             ];
 
             patterns.forEach((pattern, idx) => {
-                var splitter;
-                if(idx == 0) splitter = ":";
-                if(idx == 1) splitter = ".";
-                if(idx == 2) splitter = "_";
+                var splitter = [":", ".", "_"][idx];
 
                 var found = tableCell.innerText.match(pattern);
-
                 if(found != null){
                     found.forEach(find => {
                         var segments = find.split(splitter);
                         var table;
                         var sys_id;
-                        if(idx == 0 || idx == 1){
-                            table = segments[0];
-                            sys_id = segments[1];
-                        } else if (idx == 2){
+                        if(splitter === "_"){
                             /*
                             Given this line: `com.glide.caller.gen.sys_script_include_b0dee9462f231110c30d2ca62799b62d_script.call(Unknown Source)`
                             Pattern will give this regex match: "sys_script_include_fc70ddc629230010fa9bf7f97d737e2e"
@@ -1710,6 +1688,9 @@ function snuAddErrorLogScriptLinks() {
                             var sys_id_idx = segments.length - 1;
                             sys_id = segments[sys_id_idx];
                             table = segments.slice(0, sys_id_idx).join(splitter);
+                        } else {
+                            table = segments[0];
+                            sys_id = segments[1];
                         }
 
                         var newHtml = tableCell.innerHTML.replaceAll(


### PR DESCRIPTION
Follow up to #332, 

I'm still not very well versed in native DOM traversal/manipulation to replace the jQuery method, if you have advice on that I'll happily re-write those two jQuery functions to use native. 


Test results from running in console:

![image](https://user-images.githubusercontent.com/30616047/206165783-9bd128d2-c6a6-4b8d-b7ed-985ad833c255.png)
