### PR TITLE
Add worknote hyperlinks to task numbers #337

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -1713,7 +1713,7 @@ function snuAddErrorLogScriptLinks() {
 function snuAddWorkNoteTaskLinks() {
     if (document.querySelector('.sn-stream').length != 0) { //checks for the presense of an activity stream
         document.querySelectorAll('li.h-card',).forEach((card,cardIndex) => { // each individual card in the stream
-            var pattern = /[A-Z]{2,7}[0-9]{6,10}/gm;
+            var pattern = /[A-Z]{2,7}[0-9]{6,10}/gm; // This pattern is generic enough to capture pretty much any task number, but may have false positives
             var found = card.innerText.match(pattern);
             if(found != null){
                 found.forEach(number => {

--- a/inject.js
+++ b/inject.js
@@ -1448,6 +1448,7 @@ function snuSettingsAdded() {
         mouseEnterToConvertToHyperlink();
         snuAddGroupSortIcon();
         snuAddErrorLogScriptLinks();
+        snuAddWorkNoteTaskLinks();
         snuAddFormDesignScopeChange();
         snuAddPersonaliseListHandler();
         snuAddLinkToCachDo();
@@ -1706,6 +1707,27 @@ function snuAddErrorLogScriptLinks() {
         });
 
         setTimeout(snuAddErrorLogScriptLinks, 3000); // "recursive" call this incase we navigate to next page.
+    }
+}
+
+function snuAddWorkNoteTaskLinks() {
+    if (document.querySelector('.sn-stream').length != 0) { //checks for the presense of an activity stream
+        document.querySelectorAll('li.h-card',).forEach((card,cardIndex) => { // each individual card in the stream
+            var pattern = /[A-Z]{2,7}[0-9]{6,10}/gm;
+            var found = card.innerText.match(pattern);
+            if(found != null){
+                found.forEach(number => {
+                    var newHtml = card.innerHTML.replaceAll(
+                        number,
+                        // Using `sysparm_query=number=INC123` will handle converting from base task to the specific task table
+                        // using `sys_id=INC123` technically works, but will render certain forms on the task.do form layout 
+                        // same thing happens when `sysparm_refkey=name` is used, the task.do form layout is rendered
+                        `<a title="Link via SN Utils" target='_blank' href='/task.do?sysparm_query=number=${number}'>${number}</a>`
+                    );
+                    card.innerHTML = DOMPurify.sanitize(newHtml, { ADD_ATTR: ["target"] });
+                });
+            }
+        });
     }
 }
 


### PR DESCRIPTION
This is basically an extension of the syslog linking we did the other day. 
One major drawback I see is that we can't tell what the table is, so any non-task number that matches this regex would be picked up, such as asset numbers. 