### PR TITLE
In a diff, show the original on the left and the modified on the right

### DIFF
--- a/js/monaco/compare.js
+++ b/js/monaco/compare.js
@@ -49,8 +49,8 @@ function getCompareNames() {
     let nodeList = [...document.querySelectorAll("thead th.main")].map(el => el.innerHTML);
 
     return {
-        leftTitle: nodeList[0],
-        rightTitle: nodeList[1]
+        originalTitle: nodeList[0],
+        modifiedTitle: nodeList[1]
     };
 }
 
@@ -66,16 +66,18 @@ function openMonaceDiff(fieldName, context) {
     window.top.document.dispatchEvent(event);
 
     setTimeout(function () {
-        let rightBody = context ? context.rightBody : gel(fieldName).value;
-        let leftBody = context ? context.leftBody : _getElementByPrefix('pulled', fieldName).value;
+        // ServiceNow shows the original on modified on the left and the original on the right,
+        // however this looks wrong in a diff tool so we need to swap the values to show the correct diff
+        let originalBody = context ? context.rightBody : gel(fieldName).value;
+        let modifiedBody = context ? context.leftBody : _getElementByPrefix('pulled', fieldName).value;
 
         let names = getCompareNames();
         let data = {
             fieldName : fieldName,
-            leftBody: leftBody,
-            leftTitle: names.leftTitle,
-            rightBody: rightBody,
-            rightTitle: names.rightTitle,
+            leftBody: originalBody,
+            leftTitle: names.originalTitle,
+            rightBody: modifiedBody,
+            rightTitle: names.modifiedTitle,
             snusettings: snusettings
         };
         let event = new CustomEvent(


### PR DESCRIPTION
Fixes #370 - though welcome any comments - this seemed like the obvious place to change it, but I could be wrong!

Test on chrome,

Before:

![image](https://user-images.githubusercontent.com/1998970/221585962-b3972531-989c-446d-9d25-4ec2ca3e268d.png)

After:

![image](https://user-images.githubusercontent.com/1998970/221586045-072a4a1b-5452-4911-88b6-58f7189ef8b5.png)
