### PR TITLE
In /bgl, Wrap $encodedquery in double quotes instead of single quotes. 

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -64,7 +64,7 @@ var snuslashcommands = {
         "hint": "Background Script with var current"
     },
     "bgl": {
-        "url": "/sys.scripts.do?content=var%20list%20%3D%20new%20GlideRecord%28%27$table%27%29%3B%0Alist.addEncodedQuery%28%27$encodedquery%27%29%3B%0Alist.setLimit%2810%29%3B%0Alist.query%28%29%3B%0Awhile%20%28list.next%28%29%29%7B%0A%20%20%20%20gs.info%28list.getDisplayValue%28%29%29%3B%0A%7D%3B",
+        "url": "/sys.scripts.do?content=var%20list%20%3D%20new%20GlideRecord%28%27$table%27%29%3B%0Alist.addEncodedQuery%28%22$encodedquery%22%29%3B%0Alist.setLimit%2810%29%3B%0Alist.query%28%29%3B%0Awhile%20%28list.next%28%29%29%7B%0A%20%20%20%20gs.info%28list.getDisplayValue%28%29%29%3B%0A%7D%3B",
         "hint": "Background Script with list gr"
     },
     "cls": {


### PR DESCRIPTION
Per my comment on [Reddit](https://old.reddit.com/r/servicenow/comments/115egg8/sn_utils_browser_extension_for_working_with/jbnpxt2/), this PR replaces `%27` with `%22` to ensure that encoded queries that contain `'` already are parsed correctly. Demonstartion of difference below:

Given the following encoded query:

![image](https://user-images.githubusercontent.com/1998970/224655750-9d153180-cf63-4f12-9ad6-f57cc1194320.png)


`opened_atON2023-03-13@javascript:gs.dateGenerate('2023-03-13','start')@javascript:gs.dateGenerate('2023-03-13','end')`

Current code (using `%27`):

![image](https://user-images.githubusercontent.com/1998970/224654972-82fec27b-5d69-4745-a360-84f7f4abbde9.png)

Using `%22`:

![image](https://user-images.githubusercontent.com/1998970/224654926-7cc9ec6f-cff3-46d4-8534-c81da9ef5661.png)