### PR TITLE
Add function overload to GlideRecord addQuery

### DIFF
--- a/js/monaco/libsource.js
+++ b/js/monaco/libsource.js
@@ -316,8 +316,10 @@ class GlideServletRequest{
     /** Retrieves the name of the display field */
     getDisplayName() : string {};
     
-    /** Adds a filter to return records by specifying a field and value. You can use an optional 'operator' as a second parameter */
+    /** Add a filter to return records by specifying a field and a value it should equal */
     addQuery(name: string, value: string) : GlideQueryCondition {};
+    /** Add a filter to return records based on a field, an operator, and a value */
+    addQuery(name: string, operator: string, value: string) : GlideQueryCondition {};
     
     /** Sets the maximum number of records in the GlideRecord to be fetched in the next query */
     setLimit(limit: number) {};
@@ -2928,8 +2930,10 @@ class GlideServletRequest{
     /** Retrieves the name of the display field */
     getDisplayName() : string {};
     
-    /** Adds a filter to return records by specifying a field and value. You can use an optional 'operator' as a second parameter */
+    /** Add a filter to return records by specifying a field and a value it should equal */
     addQuery(name: string, value: string) : GlideQueryCondition {};
+    /** Add a filter to return records based on a field, an operator, and a value */
+    addQuery(name: string, operator: string, value: string) : GlideQueryCondition {};
     
     /** Sets the maximum number of records in the GlideRecord to be fetched in the next query */
     setLimit(limit: number) {};

--- a/js/monaco/libsource.js
+++ b/js/monaco/libsource.js
@@ -316,9 +316,9 @@ class GlideServletRequest{
     /** Retrieves the name of the display field */
     getDisplayName() : string {};
     
-    /** Add a filter to return records by specifying a field and a value it should equal */
+    /** Adds a filter to return records by specifying a field and a value it should equal */
     addQuery(name: string, value: string) : GlideQueryCondition {};
-    /** Add a filter to return records based on a field, an operator, and a value */
+    /** Adds a filter to return records based on a field, an operator, and a value */
     addQuery(name: string, operator: string, value: string) : GlideQueryCondition {};
     
     /** Sets the maximum number of records in the GlideRecord to be fetched in the next query */
@@ -2930,9 +2930,9 @@ class GlideServletRequest{
     /** Retrieves the name of the display field */
     getDisplayName() : string {};
     
-    /** Add a filter to return records by specifying a field and a value it should equal */
+    /** Adds a filter to return records by specifying a field and a value it should equal */
     addQuery(name: string, value: string) : GlideQueryCondition {};
-    /** Add a filter to return records based on a field, an operator, and a value */
+    /** Adds a filter to return records based on a field, an operator, and a value */
     addQuery(name: string, operator: string, value: string) : GlideQueryCondition {};
     
     /** Sets the maximum number of records in the GlideRecord to be fetched in the next query */


### PR DESCRIPTION
As per [the GlideRecord API docs](https://developer.servicenow.com/dev.do#!/reference/api/rome/server_legacy/c_GlideRecordAPI#r_GlideRecord-AddQuery_String_Object_Object?navFilter=addQuery) (and even according to the existing function description), there are two possible signatures for GlideRecord.prototype.addQuery: 2 parameters or 3 parameters.

This PR just adds an overload so both signatures get Intellisense.