### PR TITLE
Add in a context menu item to swap panes in the code diff viewer

### DIFF
--- a/js/monaco/diff.js
+++ b/js/monaco/diff.js
@@ -43,9 +43,30 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
                 else if (message.command.fieldName.includes('xml')) lang = 'xml';
                 else if (message.command.fieldName.includes('html')) lang = 'html';
 
+                let originalModel = monaco.editor.createModel(message.command.leftBody, lang);
+                let modifiedModel = monaco.editor.createModel(message.command.rightBody, lang);
+
                 editor.setModel({
-                    original: monaco.editor.createModel(message.command.leftBody, lang),
-                    modified: monaco.editor.createModel(message.command.rightBody, lang)
+                    original: originalModel,
+                    modified: modifiedModel
+                });
+
+                let swapped = false;
+                editor.addAction({
+                    id: "diff-swapper",
+                    label: "Swap Diff Panes",
+                    contextMenuGroupId: "navigation",
+
+                    run: function () {
+                        editor.setModel({
+                            original: swapped ? originalModel : modifiedModel,
+                            modified: swapped ? modifiedModel : originalModel
+                        })
+
+                        document.querySelector('#left').innerText = swapped ? message.command.leftTitle : message.command.rightTitle;
+                        document.querySelector('#right').innerText = swapped ? message.command.rightTitle : message.command.leftTitle;
+                        swapped = !swapped
+                    },
                 });
 
                 document.querySelector('.inline-it').addEventListener('change', (e) => {


### PR DESCRIPTION
Continuing on from a very old conversation in #370, sometimes it can be confusing when looking at the diff editor to know exactly what has changed between versions of a file as the diff window may be the opposite way around to what one expects it to be.

You very helpfully [applied a solution](https://github.com/arnoudkooi/ServiceNow-Utils/issues/370#issuecomment-1447208896) to programatically work this out in some cases, and I confirmed that it was working as expected - however I still find myself wanting to swap the diffs around in some situations. I figured I would roll up my sleeves and implement this myself.

This PR adds in a context menu item (right side only, [limitation of the monaco editor](https://github.com/microsoft/monaco-editor/issues/385) it seems)

In this gif, for example, the "Selected Version" is actually newer than the "Current Version" (in this case, a skipped record from a system upgrade.)

![swapit](https://github.com/arnoudkooi/ServiceNow-Utils/assets/1998970/eaedfd53-a813-4eb8-a473-a35a2d95a248)

I'm sure there are other situations where this would be useful, and it probably makes more sense to make this a manual action than trying to code for all possible situations where the orientation may be better off the other way around from default :)

[Working example on monaco playground](https://microsoft.github.io/monaco-editor/playground.html?source=v0.40.0#XQAAAAIgBQAAAAAAAABBqQkHQ5NjdMjwa-jY7SIQ9S7DNlzs5W-mwj0fe1ZCDRFc9ws9XQE0SJE1jc2VKxhaLFIw9vEWSxW3yscw7uFNiAEiAJM8XEuX7Os378jBGtVLkr6ryuhqvky-XZ9Sy0vyFSI1m9lYQpwqOsaKmhydYWIo-9hGbv_4wlPIsEpVooDN3UD2zr-vCSuzORmDceXpj7cQX_e-4g1mWsiDM86fxT73TPlNJEaKZcgo0Bi3qth633mYtZGxXsTnd5bQasxqE1D6DKTrk-p_W0HbrfjcqFS-BJd-iZDk9Cg9xc7Gyaz9kqb7nAdqz3u1IcW9dgYnkHh054tZC5kr67vrd-fZYr8MEgwEs-2jjhI0fL17Kcb7I-Y4sFMij0ZltX6kn_STBYCD7uMKiM-5zY4XhiSdjnpP6-2LMiNXSgq-2gSZ3afSqEf77jqZ8uyEERfKpboblEpUcGtyth0rq8sgxg2A0UsOFIS2Yr8ut2prjZkmGqghvIE2LS71x7ur2K_QnQTHNhTkMgrbaOQQRrBiiX1e8D_lL0vtmaBuTLUThAj5xNNH8F1IVpD7Nomc6ZSvXplcc2T2htl5V098IC6RYuyX0icWRjBj2i6ozFWAmjYOBr0gy-wwOwk9kwr5tfjsHJLreJGuZydUOkjw7LJ0g0rZp1Y1Lb6X6xoTx8ZOGaHFntmD-hte4701_KT8PLn_u6nAnFJPzy3VGIOzs65O4NUpX-o5YPiSy5TLi64Fc8kcZFEXzVSQLywTpFwn5q8DtxOkNLrQMxv_-_UCmQ)