### PR TITLE
Feature/add background script history loading

### DIFF
--- a/css/background.css
+++ b/css/background.css
@@ -56,3 +56,7 @@ pre {
 label{
     font-size:9pt;
 }
+
+pre#codepreview {
+    border: 2px solid green;
+}

--- a/js/monaco/bgscript.js
+++ b/js/monaco/bgscript.js
@@ -283,75 +283,6 @@ function startStopWatch() {
 
 function getBackgroundHistoryEntriesForUser() {
 
-	class CodeHistory {
-
-		constructor() {
-			this.history = new Map();
-			this.selectedEntry = null;
-		}
-	
-		addEntry(sysId, additionalData) {
-			if(additionalData.code !== "") {
-				this.history.set(sysId, additionalData);
-			}
-		}
-
-		generateSelect() {
-			const scrpt = document.getElementsByTagName('pre')[0];
-			const options = this.generateOptions();
-			if(this.history.size > 0) {
-				const template = `
-					<div>
-						<select id="bgscripthistory">${options}</select>
-						<pre id="codepreview"></pre>
-						<button id="load-script">Load Script</button>
-						<button>Load Script With Result</button>
-
-					</div>`;
-				//div.inner.HTML(template);
-				scrpt.insertAdjacentHTML("beforebegin", template);
-				
-				var loadScriptButton = document.getElementById('load-script');
-
-				if(loadScriptButton) {
-					loadScriptButton.addEventListener('click', function() {
-						loadScriptInEditor();
-					});
-				}				
-			}
-
-			
-
-			document.addEventListener("change", (event) => {
-				var value = event.target.value;
-				if(this.history.has(value)) {
-					this.selectedEntry = this.history.get(value);
-					//loadBackgroundScript(value);
-					/*
-					var result = document.querySelector(".result");
-					result.innerHTML = 'SN Utils - Background script result pane.<hr />' + historyEntry.result; 
-					window.monaco.editor.getModels()[0].setValue(historyEntry.code)
-					*/
-					var preview = document.querySelector("#codepreview");
-					preview.innerHTML = this.selectedEntry.code.toString();
-				}
-			});
-		}
-
-		loadScriptInEditor() {
-			editor.getModels()[0].setValue(this.selectedEntry.code.toString());
-		}
-
-		generateOptions() {
-			let options = "<option>- Select executed Script - </option>";
-			console.log(this.history);
-			this.history.forEach((value, key) => {
-				options += `<option value="${key}">${value.startedAt}</option>`;
-			});
-			return options;
-		}
-	}
-
 	const codeHistory = new CodeHistory();
 	const table = "sys_script_execution_history"
 	const fields = "sys_id,script,result,transaction.transaction_processing_time,started";
@@ -359,16 +290,9 @@ function getBackgroundHistoryEntriesForUser() {
 	const instance = window.location.origin;
 	const g_ck = document.getElementsByName('sysparm_ck')[0]?.value;
 
-	
-	// https://dev90744.service-now.com/sys_script_execution_history_list.do?sysparm_query=sys_created_by%3Ddeveloper.program%40snc&sysparm_view=
 	var client = new XMLHttpRequest();
     client.open("get", instance + '/api/now/table/' +
         table + '?sysparm_fields=' + fields + '&sysparm_query=' + filter);
-
-	/*
-	var postData = {};
-    postData[data.field] = editor.getModel().getValue();
-	*/
 
     client.setRequestHeader('Accept', 'application/json');
     client.setRequestHeader('Content-Type', 'application/json');
@@ -379,9 +303,6 @@ function getBackgroundHistoryEntriesForUser() {
             var resp = JSON.parse(this.response);
             if (resp.hasOwnProperty('result')) {
 				const results = resp.result;
-                //document.querySelector('#response').innerHTML = 'Saved: ' + new Date().toLocaleTimeString();
-                //versionid = editor.getModel().getAlternativeVersionId();
-				console.log("results received:" + JSON.stringify(results));
 				for(const result of results) {
 					const sysId = result.sys_id;
 					const code = result.script;
@@ -406,4 +327,61 @@ function getBackgroundHistoryEntriesForUser() {
         }
     };
     client.send();
+}
+
+class CodeHistory {
+
+	constructor() {
+		this.history = new Map();
+		this.selectedEntry = null;
+	}
+
+	addEntry(sysId, additionalData) {
+		if(additionalData.code !== "") {
+			this.history.set(sysId, additionalData);
+		}
+	}
+
+	generateSelect() {
+		const scrpt = document.getElementsByTagName('pre')[0];
+		const options = this.generateOptions();
+		if(this.history.size > 0) {
+			const template = `
+				<div>
+					<select id="bgscripthistory">${options}</select>
+					<pre id="codepreview"></pre>
+					<button id="load-script">Load Script</button>
+				</div>`;
+			scrpt.insertAdjacentHTML("beforebegin", template);
+			
+			var loadScriptButton = document.getElementById('load-script');
+
+			if(loadScriptButton) {
+				loadScriptButton.addEventListener('click', () => {
+					this.loadScriptInEditor();
+				});
+			}				
+		}
+
+		document.addEventListener("change", (event) => {
+			var value = event.target.value;
+			if(this.history.has(value)) {
+				this.selectedEntry = this.history.get(value);
+				var preview = document.querySelector("#codepreview");
+				preview.innerHTML = this.selectedEntry.code.toString();
+			}
+		});
+	}
+
+	loadScriptInEditor() {
+		editor.getModels()[0].setValue(this.selectedEntry.code.toString());
+	}
+
+	generateOptions() {
+		let options = "<option>- Select executed Script - </option>";
+		this.history.forEach((value, key) => {
+			options += `<option value="${key}">${value.startedAt}</option>`;
+		});
+		return options;
+	}
 }

--- a/js/monaco/bgscript.js
+++ b/js/monaco/bgscript.js
@@ -281,75 +281,77 @@ function startStopWatch() {
 	}, 100);
 }
 
-class CodeHistory {
-
-	constructor() {
-		this.history = new Map();
-		this.selectedEntry = null;
-	}
-
-	addEntry(sysId, additionalData) {
-		if(additionalData.code !== "") {
-			this.history.set(sysId, additionalData);
-		}
-	}
-
-	generateSelect() {
-		const scrpt = document.getElementsByTagName('pre')[0];
-		const options = this.generateOptions();
-		if(this.history.size > 0) {
-			const template = `
-				<div>
-					<select id="bgscripthistory">${options}</select>
-					<button id="load-script">Load Script</button>
-					<pre id="codepreview"></pre>
-				</div>`;
-			scrpt.insertAdjacentHTML("beforebegin", template);
-			
-			var loadScriptButton = document.getElementById('load-script');
-
-			if(loadScriptButton) {
-				loadScriptButton.addEventListener('click', () => {
-					this.loadScriptInEditor();
-				});
-			}				
-		}
-
-		document.addEventListener("change", (event) => {
-			var value = event.target.value;
-			if(this.history.has(value)) {
-				this.selectedEntry = this.history.get(value);
-				var preview = document.querySelector("#codepreview");
-				preview.innerHTML = this.selectedEntry.code.toString();
-			}
-		});
-	}
-
-	loadScriptInEditor() {
-		editor.getModels()[0].setValue(this.selectedEntry.code.toString());
-	}
-
-	generateOptions() {
-		let options = "<option>- Select executed Script - </option>";
-		this.history.forEach((value, key) => {
-			options += `<option value="${key}">${value.startedAt}</option>`;
-		});
-		return options;
-	}
-}
-
 function getBackgroundHistoryEntriesForUser() {
+
+	// private class start
+	class CodeHistory {
+
+		constructor() {
+			this.history = new Map();
+			this.selectedEntry = null;
+		}
+	
+		addEntry(sysId, additionalData) {
+			if(additionalData.code !== "") {
+				this.history.set(sysId, additionalData);
+			}
+		}
+	
+		generateSelect() {
+			const scrpt = document.getElementsByTagName('pre')[0];
+			const options = this.generateOptions();
+			if(this.history.size > 0) {
+				const template = `
+					<div>
+						<select id="bgscripthistory">${options}</select>
+						<button id="load-script">Load Script</button>
+						<pre id="codepreview"></pre>
+					</div>`;
+				scrpt.insertAdjacentHTML("beforebegin", template);
+				
+				var loadScriptButton = document.getElementById('load-script');
+	
+				if(loadScriptButton) {
+					loadScriptButton.addEventListener('click', () => {
+						this.loadScriptInEditor();
+					});
+				}				
+			}
+	
+			document.addEventListener("change", (event) => {
+				var value = event.target.value;
+				if(this.history.has(value)) {
+					this.selectedEntry = this.history.get(value);
+					var preview = document.querySelector("#codepreview");
+					preview.innerHTML = this.selectedEntry.code.toString();
+				}
+			});
+		}
+	
+		loadScriptInEditor() {
+			editor.getModel().setValue(this.selectedEntry.code.toString());
+		}
+	
+		generateOptions() {
+			let options = "<option>- Select executed Script - </option>";
+			this.history.forEach((value, key) => {
+				options += `<option value="${key}">${value.startedAt}</option>`;
+			});
+			return options;
+		}
+	}
+	// private class end
 
 	const codeHistory = new CodeHistory();
 	const table = "sys_script_execution_history"
 	const fields = "sys_id,script,result,transaction.transaction_processing_time,started";
-	const filter = "sys_created_by=javascript:gs.getUserName()";
+	const query = "sys_created_by=javascript:gs.getUserName()^ORDERBYDESCstarted";
 	const instance = window.location.origin;
 	const g_ck = document.getElementsByName('sysparm_ck')[0]?.value;
 
 	var client = new XMLHttpRequest();
     client.open("get", instance + '/api/now/table/' +
-        table + '?sysparm_fields=' + fields + '&sysparm_query=' + filter);
+        table + '?sysparm_fields=' + fields + '&sysparm_query=' + query);
 
     client.setRequestHeader('Accept', 'application/json');
     client.setRequestHeader('Content-Type', 'application/json');

--- a/js/monaco/bgscript.js
+++ b/js/monaco/bgscript.js
@@ -283,17 +283,92 @@ function startStopWatch() {
 
 function getBackgroundHistoryEntriesForUser() {
 
+	class CodeHistory {
+
+		constructor() {
+			this.history = new Map();
+			this.selectedEntry = null;
+		}
+	
+		addEntry(sysId, additionalData) {
+			if(additionalData.code !== "") {
+				this.history.set(sysId, additionalData);
+			}
+		}
+
+		generateSelect() {
+			const scrpt = document.getElementsByTagName('pre')[0];
+			const options = this.generateOptions();
+			if(this.history.size > 0) {
+				const template = `
+					<div>
+						<select id="bgscripthistory">${options}</select>
+						<pre id="codepreview"></pre>
+						<button id="load-script">Load Script</button>
+						<button>Load Script With Result</button>
+
+					</div>`;
+				//div.inner.HTML(template);
+				scrpt.insertAdjacentHTML("beforebegin", template);
+				
+				var loadScriptButton = document.getElementById('load-script');
+
+				if(loadScriptButton) {
+					loadScriptButton.addEventListener('click', function() {
+						loadScriptInEditor();
+					});
+				}				
+			}
+
+			
+
+			document.addEventListener("change", (event) => {
+				var value = event.target.value;
+				if(this.history.has(value)) {
+					this.selectedEntry = this.history.get(value);
+					//loadBackgroundScript(value);
+					/*
+					var result = document.querySelector(".result");
+					result.innerHTML = 'SN Utils - Background script result pane.<hr />' + historyEntry.result; 
+					window.monaco.editor.getModels()[0].setValue(historyEntry.code)
+					*/
+					var preview = document.querySelector("#codepreview");
+					preview.innerHTML = this.selectedEntry.code.toString();
+				}
+			});
+		}
+
+		loadScriptInEditor() {
+			editor.getModels()[0].setValue(this.selectedEntry.code.toString());
+		}
+
+		generateOptions() {
+			let options = "<option>- Select executed Script - </option>";
+			console.log(this.history);
+			this.history.forEach((value, key) => {
+				options += `<option value="${key}">${value.startedAt}</option>`;
+			});
+			return options;
+		}
+	}
+
 	const codeHistory = new CodeHistory();
 	const table = "sys_script_execution_history"
 	const fields = "sys_id,script,result,transaction.transaction_processing_time,started";
-	const query = "sys_created_by=javascript:gs.getUserName()^ORDERBYDESCstarted";
+	const filter = "sys_created_by=javascript:gs.getUserName()";
 	const instance = window.location.origin;
 	const g_ck = document.getElementsByName('sysparm_ck')[0]?.value;
 
+	
+	// https://dev90744.service-now.com/sys_script_execution_history_list.do?sysparm_query=sys_created_by%3Ddeveloper.program%40snc&sysparm_view=
 	var client = new XMLHttpRequest();
     client.open("get", instance + '/api/now/table/' +
-        table + '?sysparm_fields=' + fields + '&sysparm_query=' + query);
+        table + '?sysparm_fields=' + fields + '&sysparm_query=' + filter);
 
+	/*
+	var postData = {};
+    postData[data.field] = editor.getModel().getValue();
+	*/
 
     client.setRequestHeader('Accept', 'application/json');
     client.setRequestHeader('Content-Type', 'application/json');
@@ -304,6 +379,9 @@ function getBackgroundHistoryEntriesForUser() {
             var resp = JSON.parse(this.response);
             if (resp.hasOwnProperty('result')) {
 				const results = resp.result;
+                //document.querySelector('#response').innerHTML = 'Saved: ' + new Date().toLocaleTimeString();
+                //versionid = editor.getModel().getAlternativeVersionId();
+				console.log("results received:" + JSON.stringify(results));
 				for(const result of results) {
 					const sysId = result.sys_id;
 					const code = result.script;
@@ -328,70 +406,4 @@ function getBackgroundHistoryEntriesForUser() {
         }
     };
     client.send();
-}
-
-class CodeHistory {
-
-	constructor() {
-		this.history = new Map();
-		this.selectedEntry = null;
-	}
-
-	addEntry(sysId, additionalData) {
-		if(additionalData.code !== "") {
-			this.history.set(sysId, additionalData);
-		}
-	}
-
-	generateSelect() {
-		const scrpt = document.getElementsByTagName('pre')[0];
-		const options = this.generateOptions();
-		if(this.history.size > 0) {
-			const template = `
-				<div>
-					<select id="bgscripthistory">${options}</select>
-					<button id="load-script">Load Script</button>
-					<pre id="codepreview"></pre>
-				</div>`;
-			scrpt.insertAdjacentHTML("beforebegin", template);
-			
-			var loadScriptButton = document.getElementById('load-script');
-
-			if(loadScriptButton) {
-				loadScriptButton.addEventListener('click', () => {
-					this.loadScriptInEditor();
-				});
-			}				
-		}
-
-		
-
-		document.addEventListener("change", (event) => {
-			var value = event.target.value;
-			if(this.history.has(value)) {
-				this.selectedEntry = this.history.get(value);
-				//loadBackgroundScript(value);
-				/*
-				var result = document.querySelector(".result");
-				result.innerHTML = 'SN Utils - Background script result pane.<hr />' + historyEntry.result; 
-				window.monaco.editor.getModels()[0].setValue(historyEntry.code)
-				*/
-				var preview = document.querySelector("#codepreview");
-				preview.innerHTML = this.selectedEntry.code.toString();
-			}
-		});
-	}
-
-	loadScriptInEditor() {
-		window.monaco.editor.getModels()[0].setValue(this.selectedEntry.code.toString());
-	}
-
-	generateOptions() {
-		let options = "<option>- Select executed Script - </option>";
-		console.log(this.history);
-		this.history.forEach((value, key) => {
-			options += `<option value="${key}">${value.startedAt}</option>`;
-		});
-		return options;
-	}
 }

--- a/js/monaco/bgscript.js
+++ b/js/monaco/bgscript.js
@@ -281,6 +281,63 @@ function startStopWatch() {
 	}, 100);
 }
 
+class CodeHistory {
+
+	constructor() {
+		this.history = new Map();
+		this.selectedEntry = null;
+	}
+
+	addEntry(sysId, additionalData) {
+		if(additionalData.code !== "") {
+			this.history.set(sysId, additionalData);
+		}
+	}
+
+	generateSelect() {
+		const scrpt = document.getElementsByTagName('pre')[0];
+		const options = this.generateOptions();
+		if(this.history.size > 0) {
+			const template = `
+				<div>
+					<select id="bgscripthistory">${options}</select>
+					<button id="load-script">Load Script</button>
+					<pre id="codepreview"></pre>
+				</div>`;
+			scrpt.insertAdjacentHTML("beforebegin", template);
+			
+			var loadScriptButton = document.getElementById('load-script');
+
+			if(loadScriptButton) {
+				loadScriptButton.addEventListener('click', () => {
+					this.loadScriptInEditor();
+				});
+			}				
+		}
+
+		document.addEventListener("change", (event) => {
+			var value = event.target.value;
+			if(this.history.has(value)) {
+				this.selectedEntry = this.history.get(value);
+				var preview = document.querySelector("#codepreview");
+				preview.innerHTML = this.selectedEntry.code.toString();
+			}
+		});
+	}
+
+	loadScriptInEditor() {
+		editor.getModels()[0].setValue(this.selectedEntry.code.toString());
+	}
+
+	generateOptions() {
+		let options = "<option>- Select executed Script - </option>";
+		this.history.forEach((value, key) => {
+			options += `<option value="${key}">${value.startedAt}</option>`;
+		});
+		return options;
+	}
+}
+
 function getBackgroundHistoryEntriesForUser() {
 
 	const codeHistory = new CodeHistory();
@@ -327,61 +384,4 @@ function getBackgroundHistoryEntriesForUser() {
         }
     };
     client.send();
-}
-
-class CodeHistory {
-
-	constructor() {
-		this.history = new Map();
-		this.selectedEntry = null;
-	}
-
-	addEntry(sysId, additionalData) {
-		if(additionalData.code !== "") {
-			this.history.set(sysId, additionalData);
-		}
-	}
-
-	generateSelect() {
-		const scrpt = document.getElementsByTagName('pre')[0];
-		const options = this.generateOptions();
-		if(this.history.size > 0) {
-			const template = `
-				<div>
-					<select id="bgscripthistory">${options}</select>
-					<pre id="codepreview"></pre>
-					<button id="load-script">Load Script</button>
-				</div>`;
-			scrpt.insertAdjacentHTML("beforebegin", template);
-			
-			var loadScriptButton = document.getElementById('load-script');
-
-			if(loadScriptButton) {
-				loadScriptButton.addEventListener('click', () => {
-					this.loadScriptInEditor();
-				});
-			}				
-		}
-
-		document.addEventListener("change", (event) => {
-			var value = event.target.value;
-			if(this.history.has(value)) {
-				this.selectedEntry = this.history.get(value);
-				var preview = document.querySelector("#codepreview");
-				preview.innerHTML = this.selectedEntry.code.toString();
-			}
-		});
-	}
-
-	loadScriptInEditor() {
-		editor.getModels()[0].setValue(this.selectedEntry.code.toString());
-	}
-
-	generateOptions() {
-		let options = "<option>- Select executed Script - </option>";
-		this.history.forEach((value, key) => {
-			options += `<option value="${key}">${value.startedAt}</option>`;
-		});
-		return options;
-	}
 }

--- a/js/monaco/bgscript.js
+++ b/js/monaco/bgscript.js
@@ -283,92 +283,17 @@ function startStopWatch() {
 
 function getBackgroundHistoryEntriesForUser() {
 
-	class CodeHistory {
-
-		constructor() {
-			this.history = new Map();
-			this.selectedEntry = null;
-		}
-	
-		addEntry(sysId, additionalData) {
-			if(additionalData.code !== "") {
-				this.history.set(sysId, additionalData);
-			}
-		}
-
-		generateSelect() {
-			const scrpt = document.getElementsByTagName('pre')[0];
-			const options = this.generateOptions();
-			if(this.history.size > 0) {
-				const template = `
-					<div>
-						<select id="bgscripthistory">${options}</select>
-						<pre id="codepreview"></pre>
-						<button id="load-script">Load Script</button>
-						<button>Load Script With Result</button>
-
-					</div>`;
-				//div.inner.HTML(template);
-				scrpt.insertAdjacentHTML("beforebegin", template);
-				
-				var loadScriptButton = document.getElementById('load-script');
-
-				if(loadScriptButton) {
-					loadScriptButton.addEventListener('click', function() {
-						loadScriptInEditor();
-					});
-				}				
-			}
-
-			
-
-			document.addEventListener("change", (event) => {
-				var value = event.target.value;
-				if(this.history.has(value)) {
-					this.selectedEntry = this.history.get(value);
-					//loadBackgroundScript(value);
-					/*
-					var result = document.querySelector(".result");
-					result.innerHTML = 'SN Utils - Background script result pane.<hr />' + historyEntry.result; 
-					window.monaco.editor.getModels()[0].setValue(historyEntry.code)
-					*/
-					var preview = document.querySelector("#codepreview");
-					preview.innerHTML = this.selectedEntry.code.toString();
-				}
-			});
-		}
-
-		loadScriptInEditor() {
-			editor.getModels()[0].setValue(this.selectedEntry.code.toString());
-		}
-
-		generateOptions() {
-			let options = "<option>- Select executed Script - </option>";
-			console.log(this.history);
-			this.history.forEach((value, key) => {
-				options += `<option value="${key}">${value.startedAt}</option>`;
-			});
-			return options;
-		}
-	}
-
 	const codeHistory = new CodeHistory();
 	const table = "sys_script_execution_history"
 	const fields = "sys_id,script,result,transaction.transaction_processing_time,started";
-	const filter = "sys_created_by=javascript:gs.getUserName()";
+	const query = "sys_created_by=javascript:gs.getUserName()^ORDERBYDESCstarted";
 	const instance = window.location.origin;
 	const g_ck = document.getElementsByName('sysparm_ck')[0]?.value;
 
-	
-	// https://dev90744.service-now.com/sys_script_execution_history_list.do?sysparm_query=sys_created_by%3Ddeveloper.program%40snc&sysparm_view=
 	var client = new XMLHttpRequest();
     client.open("get", instance + '/api/now/table/' +
-        table + '?sysparm_fields=' + fields + '&sysparm_query=' + filter);
+        table + '?sysparm_fields=' + fields + '&sysparm_query=' + query);
 
-	/*
-	var postData = {};
-    postData[data.field] = editor.getModel().getValue();
-	*/
 
     client.setRequestHeader('Accept', 'application/json');
     client.setRequestHeader('Content-Type', 'application/json');
@@ -379,9 +304,6 @@ function getBackgroundHistoryEntriesForUser() {
             var resp = JSON.parse(this.response);
             if (resp.hasOwnProperty('result')) {
 				const results = resp.result;
-                //document.querySelector('#response').innerHTML = 'Saved: ' + new Date().toLocaleTimeString();
-                //versionid = editor.getModel().getAlternativeVersionId();
-				console.log("results received:" + JSON.stringify(results));
 				for(const result of results) {
 					const sysId = result.sys_id;
 					const code = result.script;
@@ -406,4 +328,70 @@ function getBackgroundHistoryEntriesForUser() {
         }
     };
     client.send();
+}
+
+class CodeHistory {
+
+	constructor() {
+		this.history = new Map();
+		this.selectedEntry = null;
+	}
+
+	addEntry(sysId, additionalData) {
+		if(additionalData.code !== "") {
+			this.history.set(sysId, additionalData);
+		}
+	}
+
+	generateSelect() {
+		const scrpt = document.getElementsByTagName('pre')[0];
+		const options = this.generateOptions();
+		if(this.history.size > 0) {
+			const template = `
+				<div>
+					<select id="bgscripthistory">${options}</select>
+					<button id="load-script">Load Script</button>
+					<pre id="codepreview"></pre>
+				</div>`;
+			scrpt.insertAdjacentHTML("beforebegin", template);
+			
+			var loadScriptButton = document.getElementById('load-script');
+
+			if(loadScriptButton) {
+				loadScriptButton.addEventListener('click', () => {
+					this.loadScriptInEditor();
+				});
+			}				
+		}
+
+		
+
+		document.addEventListener("change", (event) => {
+			var value = event.target.value;
+			if(this.history.has(value)) {
+				this.selectedEntry = this.history.get(value);
+				//loadBackgroundScript(value);
+				/*
+				var result = document.querySelector(".result");
+				result.innerHTML = 'SN Utils - Background script result pane.<hr />' + historyEntry.result; 
+				window.monaco.editor.getModels()[0].setValue(historyEntry.code)
+				*/
+				var preview = document.querySelector("#codepreview");
+				preview.innerHTML = this.selectedEntry.code.toString();
+			}
+		});
+	}
+
+	loadScriptInEditor() {
+		window.monaco.editor.getModels()[0].setValue(this.selectedEntry.code.toString());
+	}
+
+	generateOptions() {
+		let options = "<option>- Select executed Script - </option>";
+		console.log(this.history);
+		this.history.forEach((value, key) => {
+			options += `<option value="${key}">${value.startedAt}</option>`;
+		});
+		return options;
+	}
 }


### PR DESCRIPTION
Hey @arnoudkooi,

the idea of the pull request is to use the script execution history to load prior executed scripts by the user again in the background script.

Let me know if you want to integrate it, want to have some changes before or have improvement suggestions.

Best regards,
Jan

<img width="984" alt="Bildschirmfoto 2024-02-08 um 11 24 31" src="https://github.com/arnoudkooi/ServiceNow-Utils/assets/2991341/3f9c4aa0-3151-4782-bc72-5400101e9da8">
