### PR TITLE
adds new slash command "sfc" for showing full cell content

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -239,6 +239,10 @@ var snuslashcommands = {
         "url": "//sa",
         "hint": "Special slashcommand, accessible via extension keyboard shortcut"
     },
+    "sfc": {
+        "url": "*",
+        "hint": "Shows the full content of cells which are truncated with '...' in lists"
+    },
     "start": {
         "url": "/nav_to.do",
         "hint": "New tab"
@@ -893,6 +897,11 @@ function snuSlashCommandAddListener() {
             }
             else if (shortcut == "copycells" || shortcut == "copycolumn") {
                 snuCopySelectedCellValues(query, shortcut);
+                snuSlashCommandHide();
+                return;
+            }
+            else if (shortcut == "sfc") {
+                snuShowFullCellValues(query, shortcut);
                 snuSlashCommandHide();
                 return;
             }
@@ -3760,6 +3769,41 @@ function snuCopySelectedCellValues(copySysIDs, shortcut = "copycells") {
         return;
     }
 };
+
+function snuShowFullCellValues() {
+    var iframe = window.top.document.querySelector("iframe#gsft_main");
+    var globalNavConfigElement = document.querySelector("[global-navigation-config]");
+    var iframePolaris = globalNavConfigElement ? globalNavConfigElement.shadowRoot.querySelector("iframe#gsft_main") : null;
+    
+    var target;
+    if (iframe) {
+        target = iframe.contentDocument;
+    } else if (iframePolaris) {
+        target = iframePolaris.contentDocument;
+    } else {
+        target = document;
+    }
+    target.querySelectorAll('td').forEach(function(cell) {
+        // Check if the cell text itself ends with '....'
+        if (cell.textContent.trim().endsWith('...')) {
+            var fullText = cell.getAttribute('title') || cell.getAttribute('data-original-title');
+            if (fullText) {
+                cell.textContent = fullText;
+            }
+        }
+    
+        // Also, check for any links within the cell that have an aria-label ending with '....'
+        var links = cell.querySelectorAll('a');
+        links.forEach(function(link) {
+            if (link.getAttribute('aria-label') && link.getAttribute('aria-label').endsWith('....')) {
+                var linkFullText = link.getAttribute('title') || link.getAttribute('data-original-title');
+                if (linkFullText) {
+                    link.textContent = linkFullText;
+                }
+            }
+        });
+    });
+}
 
 async function snuPostRequestToScriptSync(requestType) {
 


### PR DESCRIPTION
Hi @arnoudkooi,

I often came into a situation, that i wanted to see the full content of cells, where ServiceNow truncates the content.
With this slash command one can expand all cell content in lists for Platform UI, Polaris and for both Layouts without Navigation. Related Lists should also work.

<img width="1511" alt="Bildschirmfoto 2024-02-08 um 13 58 45" src="https://github.com/arnoudkooi/ServiceNow-Utils/assets/2991341/b72f2ed8-793a-4bfa-8a76-dfa2e9404feb">
<img width="1512" alt="Bildschirmfoto 2024-02-08 um 13 59 05" src="https://github.com/arnoudkooi/ServiceNow-Utils/assets/2991341/cd31c12a-4113-4c16-9af1-88fbc6bcd113">
