### PR TITLE
Fix syntax error introduced in 8b3c9e + param name in snuStartBackgroundScript

### DIFF
--- a/scriptsync.js
+++ b/scriptsync.js
@@ -685,7 +685,7 @@ function changeFavicon(src) {
  * @param  {String} action {name of the action)}
  * @return {undefined}
  */
-function snuStartBackgroundScript(script, instance, callback) {
+function snuStartBackgroundScript(script, instance, action) {
     document.querySelector('base').setAttribute('href', instance.url + '/');
 
     try {
@@ -704,7 +704,7 @@ function snuStartBackgroundScript(script, instance, callback) {
             }).toString()
         }).then(response => response.text())
             .then((data) => {
-                let data = data.replace("<HTML><BODY>", "").replace("</BODY><HTML>", "");
+                data = data.replace("<HTML><BODY>", "").replace("</BODY><HTML>", "");
                 if (action == "executeBackgroundScript"){ 
                     let response = {
                         action : "responseFromBackgroundScript",

--- a/scriptsync.js
+++ b/scriptsync.js
@@ -151,6 +151,9 @@ $(document).ready(function () {
             msgCnt++;
             let wsObj = JSON.parse(evt.data);
             let instanceurl = wsObj?.instance?.url;
+
+            console.log(wsObj);
+
             if (instanceurl && scriptsyncinstances?.allowed?.includes(instanceurl)) {
                 // cleared!
             }
@@ -176,11 +179,11 @@ $(document).ready(function () {
                 return false;
             }
 
+            if (wsObj.hasOwnProperty('mirrorbgscript')) {
+                mirrorBgScript(wsObj);
+            }
             if (wsObj.hasOwnProperty('liveupdate')) {
                 updateRealtimeBrowser(wsObj);
-            }
-            else if (wsObj.hasOwnProperty('mirrorbgscript')) {
-                mirrorBgScript(wsObj);
             }
             else if (wsObj.hasOwnProperty('refreshedtoken')) {
                 refreshedToken(wsObj);

--- a/scriptsync.js
+++ b/scriptsync.js
@@ -152,8 +152,6 @@ $(document).ready(function () {
             let wsObj = JSON.parse(evt.data);
             let instanceurl = wsObj?.instance?.url;
 
-            console.log(wsObj);
-
             if (instanceurl && scriptsyncinstances?.allowed?.includes(instanceurl)) {
                 // cleared!
             }
@@ -179,11 +177,11 @@ $(document).ready(function () {
                 return false;
             }
 
-            if (wsObj.hasOwnProperty('mirrorbgscript')) {
-                mirrorBgScript(wsObj);
-            }
             if (wsObj.hasOwnProperty('liveupdate')) {
                 updateRealtimeBrowser(wsObj);
+            }
+            else if (wsObj.hasOwnProperty('mirrorbgscript')) {
+                mirrorBgScript(wsObj);
             }
             else if (wsObj.hasOwnProperty('refreshedtoken')) {
                 refreshedToken(wsObj);


### PR DESCRIPTION
![image](https://github.com/arnoudkooi/ServiceNow-Utils/assets/32551454/1ede268f-17db-499e-8a3e-3713609b14f9)

See issue displayed above, this PR removes the `let` causing an error on scriptsync.js:707 preventing the Mirror Background Script functionality from working. Also renames the callback parameter to action matching the JSDoc annotation.